### PR TITLE
Added deprecated flag to metadata via Dist::Zilla::Plugin::Deprecated

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,5 @@
+ Sean Zellmer
+    - Added deprecated flag to metadata
 2011 Aug 02
  Alexandr Ciornii
     - search for dprofpp inside bin/ directory

--- a/dist.ini
+++ b/dist.ini
@@ -12,6 +12,7 @@ main_module = DProf.pm
 [MetaConfig]
 [MetaJSON]
 [PodSyntaxTests]
+[Deprecated]
 
 [MetaResources]
 repository.type   = git


### PR DESCRIPTION
Adding this flag to the metadata will potentially add a visual indicator on metacpan that it is deprecated.

For more info, [checkout this article by Neil Bowers](http://neilb.org/2015/01/17/deprecated-metadata.html).

This is part of the CPAN PR Challenge.
